### PR TITLE
Fix E254 errors under Linux

### DIFF
--- a/colors/vimdark.vim
+++ b/colors/vimdark.vim
@@ -31,99 +31,99 @@ let g:colors_name = 'vimdark'
 " cyan:           #4DC5C6
 
 set background=dark
-hi Normal       ctermbg=234  ctermfg=246 cterm=None         guibg=000000  guifg=#949494 
-hi NormalFloat  ctermbg=234  ctermfg=246 cterm=None         guibg=000000  guifg=#949494 
-hi Nontext      ctermbg=234  ctermfg=246 cterm=None         guibg=000000  guifg=#949494 
+hi Normal       ctermbg=234  ctermfg=246 cterm=NONE         guibg=#000000  guifg=#949494 
+hi NormalFloat  ctermbg=234  ctermfg=246 cterm=NONE         guibg=#000000  guifg=#949494 
+hi Nontext      ctermbg=234  ctermfg=246 cterm=NONE         guibg=#000000  guifg=#949494 
 hi Question     ctermbg=234  ctermfg=246 cterm=Bold         guibg=#1c1c1c  guifg=#949494 gui=Bold
 hi MoreMsg      ctermbg=234  ctermfg=246 cterm=Bold         guibg=#1c1c1c  guifg=#949494 gui=Bold
-hi Visual       ctermbg=110  ctermfg=000 cterm=None         guibg=#87afd7  guifg=#000000 gui=None
-hi Comment      ctermbg=None ctermfg=242 cterm=None         guibg=None guifg=#6c6c6c gui=None
-hi Constant     ctermbg=None ctermfg=110 cterm=None         guibg=None guifg=#87afd7 gui=None
-hi String       ctermbg=None ctermfg=131 cterm=None         guibg=None guifg=#af5f5f gui=None
-hi Character    ctermbg=None ctermfg=031 cterm=None         guibg=None guifg=#0087af gui=None
-hi Identifier   ctermbg=None ctermfg=None cterm=None        guibg=None guifg=None gui=None
-hi Statement    ctermbg=None ctermfg=254 cterm=None         guibg=None guifg=#e4e4e4 gui=None
-hi PreProc      ctermbg=None ctermfg=254 cterm=None         guibg=None guifg=#e4e4e4 gui=None
-hi Operator     ctermbg=None ctermfg=131 cterm=None         guibg=None guifg=#af5f5f gui=None
-hi Type         ctermbg=None ctermfg=110 cterm=None         guibg=None guifg=#87afd7 gui=None
-hi Keyword      ctermbg=None ctermfg=110 cterm=None         guibg=None guifg=#87afd7 gui=None
-hi Special      ctermbg=None ctermfg=110 cterm=None         guibg=None guifg=#87afd7 gui=None
-hi Underlined   ctermbg=None ctermfg=None cterm=Underline   guibg=None guifg=None gui=Underline
-hi Ignore       ctermbg=None ctermfg=None cterm=None        guibg=None guifg=None gui=None
-hi Error        ctermbg=None ctermfg=196 cterm=None         guibg=None guifg=#ff0000 gui=None
-hi ErrorMsg     ctermbg=131  ctermfg=246 cterm=None         guibg=#af5f5f guifg=#e4e4e4 gui=None
-hi Warning      ctermbg=None ctermfg=110 cterm=None         guibg=None guifg=#87afd7 gui=None
-hi WarningMsg   ctermbg=None ctermfg=110 cterm=None         guibg=None guifg=#87afd7 gui=None
-hi Todo         ctermbg=None ctermfg=110 cterm=None         guibg=None guifg=#87afd7 gui=None
-hi Cursor       ctermbg=242 ctermfg=254 cterm=None          guibg=#6c6c6c guifg=#e4e4e4 gui=None
-hi CursorLine   ctermbg=242  ctermfg=254 cterm=None         guibg=#262626  guifg=#e4e4e4 gui=Bold
+hi Visual       ctermbg=110  ctermfg=000 cterm=NONE         guibg=#87afd7  guifg=#000000 gui=NONE
+hi Comment      ctermbg=NONE ctermfg=242 cterm=NONE         guibg=NONE guifg=#6c6c6c gui=NONE
+hi Constant     ctermbg=NONE ctermfg=110 cterm=NONE         guibg=NONE guifg=#87afd7 gui=NONE
+hi String       ctermbg=NONE ctermfg=131 cterm=NONE         guibg=NONE guifg=#af5f5f gui=NONE
+hi Character    ctermbg=NONE ctermfg=031 cterm=NONE         guibg=NONE guifg=#0087af gui=NONE
+hi Identifier   ctermbg=NONE ctermfg=NONE cterm=NONE        guibg=NONE guifg=NONE gui=NONE
+hi Statement    ctermbg=NONE ctermfg=254 cterm=NONE         guibg=NONE guifg=#e4e4e4 gui=NONE
+hi PreProc      ctermbg=NONE ctermfg=254 cterm=NONE         guibg=NONE guifg=#e4e4e4 gui=NONE
+hi Operator     ctermbg=NONE ctermfg=131 cterm=NONE         guibg=NONE guifg=#af5f5f gui=NONE
+hi Type         ctermbg=NONE ctermfg=110 cterm=NONE         guibg=NONE guifg=#87afd7 gui=NONE
+hi Keyword      ctermbg=NONE ctermfg=110 cterm=NONE         guibg=NONE guifg=#87afd7 gui=NONE
+hi Special      ctermbg=NONE ctermfg=110 cterm=NONE         guibg=NONE guifg=#87afd7 gui=NONE
+hi Underlined   ctermbg=NONE ctermfg=NONE cterm=Underline   guibg=NONE guifg=NONE gui=Underline
+hi Ignore       ctermbg=NONE ctermfg=NONE cterm=NONE        guibg=NONE guifg=NONE gui=NONE
+hi Error        ctermbg=NONE ctermfg=196 cterm=NONE         guibg=NONE guifg=#ff0000 gui=NONE
+hi ErrorMsg     ctermbg=131  ctermfg=246 cterm=NONE         guibg=#af5f5f guifg=#e4e4e4 gui=NONE
+hi Warning      ctermbg=NONE ctermfg=110 cterm=NONE         guibg=NONE guifg=#87afd7 gui=NONE
+hi WarningMsg   ctermbg=NONE ctermfg=110 cterm=NONE         guibg=NONE guifg=#87afd7 gui=NONE
+hi Todo         ctermbg=NONE ctermfg=110 cterm=NONE         guibg=NONE guifg=#87afd7 gui=NONE
+hi Cursor       ctermbg=242 ctermfg=254 cterm=NONE          guibg=#6c6c6c guifg=#e4e4e4 gui=NONE
+hi CursorLine   ctermbg=242  ctermfg=254 cterm=NONE         guibg=#262626  guifg=#e4e4e4 gui=Bold
 hi Directory    ctermbg=234  ctermfg=254 cterm=Underline    guibg=#1c1c1c  guifg=#e4e4e4 gui=Underline
-hi VertSplit    ctermbg=None ctermfg=242 cterm=Bold         guibg=None guifg=#6c6c6c gui=Bold
-hi Folded       ctermbg=None ctermfg=None cterm=None        guibg=None guifg=None gui=None
-hi FoldColumn   ctermbg=None ctermfg=246 cterm=None         guibg=None guifg=#949494 gui=None
-hi SignColumn   ctermbg=None ctermfg=None cterm=None        guibg=None guifg=None gui=None
+hi VertSplit    ctermbg=NONE ctermfg=242 cterm=Bold         guibg=NONE guifg=#6c6c6c gui=Bold
+hi Folded       ctermbg=NONE ctermfg=NONE cterm=NONE        guibg=NONE guifg=NONE gui=NONE
+hi FoldColumn   ctermbg=NONE ctermfg=246 cterm=NONE         guibg=NONE guifg=#949494 gui=NONE
+hi SignColumn   ctermbg=NONE ctermfg=NONE cterm=NONE        guibg=NONE guifg=NONE gui=NONE
 hi IncSearch    ctermbg=227  ctermfg=000 cterm=BOLD         guibg=#d7934f  guifg=#ffffff gui=Bold
 hi Search       ctermbg=227  ctermfg=000 cterm=BOLD         guibg=#d7934f  guifg=#ffffff gui=Bold
-hi LineNr       ctermbg=None ctermfg=242 cterm=None         guibg=None guifg=#6c6c6c gui=None
-hi CursorLineNr ctermbg=None ctermfg=242 cterm=Bold         guibg=None guifg=#6c6c6c gui=Bold
-hi MatchParen   ctermbg=235  ctermfg=246 cterm=None         guibg=#262626  guifg=#949494 gui=None
-hi Pmenu        ctermbg=235  ctermfg=254 cterm=None         guibg=#262626  guifg=#e4e4e4 gui=None
+hi LineNr       ctermbg=NONE ctermfg=242 cterm=NONE         guibg=NONE guifg=#6c6c6c gui=NONE
+hi CursorLineNr ctermbg=NONE ctermfg=242 cterm=Bold         guibg=NONE guifg=#6c6c6c gui=Bold
+hi MatchParen   ctermbg=235  ctermfg=246 cterm=NONE         guibg=#262626  guifg=#949494 gui=NONE
+hi Pmenu        ctermbg=235  ctermfg=254 cterm=NONE         guibg=#262626  guifg=#e4e4e4 gui=NONE
 hi PmenuSel     ctermbg=110  ctermfg=235 cterm=Bold         guibg=#87afd7  guifg=#262626 gui=Bold
-hi PmenuSbar    ctermbg=235  ctermfg=254 cterm=None         guibg=#262626  guifg=#e4e4e4 gui=None
-hi PmenuThumb   ctermbg=110  ctermfg=254 cterm=None         guibg=#87afd7  guifg=#e4e4e4 gui=None
-hi SpecialKey   ctermbg=None ctermfg=024 cterm=None         guibg=None guifg=#005f87 gui=None
-hi StatusLine   ctermbg=235  ctermfg=254 cterm=Bold         guibg=#262626  guifg=#e4e44 gui=Bold
-hi StatusLineNC ctermbg=242  ctermfg=235 cterm=None         guibg=#6c6c6c  guifg=#262626 gui=None
+hi PmenuSbar    ctermbg=235  ctermfg=254 cterm=NONE         guibg=#262626  guifg=#e4e4e4 gui=NONE
+hi PmenuThumb   ctermbg=110  ctermfg=254 cterm=NONE         guibg=#87afd7  guifg=#e4e4e4 gui=NONE
+hi SpecialKey   ctermbg=NONE ctermfg=024 cterm=NONE         guibg=NONE guifg=#005f87 gui=NONE
+hi StatusLine   ctermbg=235  ctermfg=254 cterm=Bold         guibg=#262626  guifg=#e4e4e4 gui=Bold
+hi StatusLineNC ctermbg=242  ctermfg=235 cterm=NONE         guibg=#6c6c6c  guifg=#262626 gui=NONE
 hi WildMenu     ctermbg=110  ctermfg=235 cterm=Bold         guibg=#87afd7  guifg=#262626 gui=Bold
-hi TabLine      ctermbg=235  ctermfg=254 cterm=None         guibg=#262626  guifg=#e4e4e4 gui=None
-hi TabLineFill  ctermbg=235  ctermfg=254 cterm=None         guibg=#262626  guifg=#e4e4e4 gui=None
+hi TabLine      ctermbg=235  ctermfg=254 cterm=NONE         guibg=#262626  guifg=#e4e4e4 gui=NONE
+hi TabLineFill  ctermbg=235  ctermfg=254 cterm=NONE         guibg=#262626  guifg=#e4e4e4 gui=NONE
 hi TabLineSel   ctermbg=227  ctermfg=235 cterm=Bold         guibg=#ffffaf  guifg=#262626 gui=Bold
-hi Title        ctermbg=None ctermfg=None cterm=Bold        guibg=None guifg=None gui=Bold
-hi DiffAdd      ctermbg=108  ctermfg=000 cterm=None         guibg=#87af87  guifg=#000000 gui=None
-hi DiffDelete   ctermbg=131  ctermfg=000 cterm=None         guibg=#af5f5f  guifg=#000000 gui=None
-hi DiffChange   ctermbg=110  ctermfg=000 cterm=None         guibg=#87afd7  guifg=#000000 gui=None
-hi DiffText     ctermbg=108  ctermfg=000 cterm=None         guibg=#87af87  guifg=#000000 gui=None
-hi qfLineNr     ctermbg=None ctermfg=246 cterm=Bold         guibg=None guifg=#949494 gui=Bold
+hi Title        ctermbg=NONE ctermfg=NONE cterm=Bold        guibg=NONE guifg=NONE gui=Bold
+hi DiffAdd      ctermbg=108  ctermfg=000 cterm=NONE         guibg=#87af87  guifg=#000000 gui=NONE
+hi DiffDelete   ctermbg=131  ctermfg=000 cterm=NONE         guibg=#af5f5f  guifg=#000000 gui=NONE
+hi DiffChange   ctermbg=110  ctermfg=000 cterm=NONE         guibg=#87afd7  guifg=#000000 gui=NONE
+hi DiffText     ctermbg=108  ctermfg=000 cterm=NONE         guibg=#87af87  guifg=#000000 gui=NONE
+hi qfLineNr     ctermbg=NONE ctermfg=246 cterm=Bold         guibg=NONE guifg=#949494 gui=Bold
 
 "golang
-hi goField              ctermbg=None ctermfg=None cterm=None   guibg=None guifg=None gui=None
-hi goType               ctermbg=None ctermfg=131  cterm=None   guibg=None guifg=#af5f5f gui=None
-hi goSignedInts         ctermbg=None ctermfg=131  cterm=None   guibg=None guifg=#af5f5f gui=None
-hi goUnsignedInts       ctermbg=None ctermfg=131  cterm=None   guibg=None guifg=#af5f5f gui=None
-hi goFloats             ctermbg=None ctermfg=131  cterm=None   guibg=None guifg=#af5f5f gui=None
-hi goFloats             ctermbg=None ctermfg=131  cterm=None   guibg=None guifg=#af5f5f gui=None
-hi goDiagnosticError    ctermbg=None ctermfg=None  cterm=None  guibg=None guifg=None gui=None
-hi goDiagnosticWarning  ctermbg=None ctermfg=None  cterm=None  guibg=None guifg=None gui=None
+hi goField              ctermbg=NONE ctermfg=NONE cterm=NONE   guibg=NONE guifg=NONE gui=NONE
+hi goType               ctermbg=NONE ctermfg=131  cterm=NONE   guibg=NONE guifg=#af5f5f gui=NONE
+hi goSignedInts         ctermbg=NONE ctermfg=131  cterm=NONE   guibg=NONE guifg=#af5f5f gui=NONE
+hi goUnsignedInts       ctermbg=NONE ctermfg=131  cterm=NONE   guibg=NONE guifg=#af5f5f gui=NONE
+hi goFloats             ctermbg=NONE ctermfg=131  cterm=NONE   guibg=NONE guifg=#af5f5f gui=NONE
+hi goFloats             ctermbg=NONE ctermfg=131  cterm=NONE   guibg=NONE guifg=#af5f5f gui=NONE
+hi goDiagnosticError    ctermbg=NONE ctermfg=NONE  cterm=NONE  guibg=NONE guifg=NONE gui=NONE
+hi goDiagnosticWarning  ctermbg=NONE ctermfg=NONE  cterm=NONE  guibg=NONE guifg=NONE gui=NONE
 
 "javascript
-hi jsObjectKey ctermbg=None ctermfg=131 cterm=None guibg=None guifg=#af5f5f gui=None
+hi jsObjectKey ctermbg=NONE ctermfg=131 cterm=NONE guibg=NONE guifg=#af5f5f gui=NONE
 
 " python
-hi pythonClassVar    ctermbg=None ctermfg=131 cterm=None guibg=None guifg=#af5f5f gui=None
-hi pythonDottedName  ctermbg=None ctermfg=131 cterm=None guibg=None guifg=#af5f5f gui=None
-hi pythonDottedName  ctermbg=None ctermfg=131 cterm=None guibg=None guifg=#af5f5f gui=None
-hi pythonBuiltinFunc ctermbg=None ctermfg=131 cterm=None guibg=None guifg=#af5f5f gui=None
+hi pythonClassVar    ctermbg=NONE ctermfg=131 cterm=NONE guibg=NONE guifg=#af5f5f gui=NONE
+hi pythonDottedName  ctermbg=NONE ctermfg=131 cterm=NONE guibg=NONE guifg=#af5f5f gui=NONE
+hi pythonDottedName  ctermbg=NONE ctermfg=131 cterm=NONE guibg=NONE guifg=#af5f5f gui=NONE
+hi pythonBuiltinFunc ctermbg=NONE ctermfg=131 cterm=NONE guibg=NONE guifg=#af5f5f gui=NONE
 
 "c++/c
-hi cppSTLios      ctermbg=None ctermfg=131 guibg=None guifg=#af5f5f
-hi cCustomFunc    ctermbg=None ctermfg=131 guibg=None guifg=#af5f5f
-hi cStructure     ctermbg=None ctermfg=131 guibg=None guifg=#af5f5f
+hi cppSTLios      ctermbg=NONE ctermfg=131 guibg=NONE guifg=#af5f5f
+hi cCustomFunc    ctermbg=NONE ctermfg=131 guibg=NONE guifg=#af5f5f
+hi cStructure     ctermbg=NONE ctermfg=131 guibg=NONE guifg=#af5f5f
 
-hi helpExample ctermbg=None ctermfg=110 cterm=None guibg=None guifg=#87afd7 gui=None
-hi helpCommand ctermbg=None ctermfg=110 cterm=None guibg=None guifg=#87afd7 gui=None
+hi helpExample ctermbg=NONE ctermfg=110 cterm=NONE guibg=NONE guifg=#87afd7 gui=NONE
+hi helpCommand ctermbg=NONE ctermfg=110 cterm=NONE guibg=NONE guifg=#87afd7 gui=NONE
 
 "TreeSitter
-hi TSConstant ctermbg=None ctermfg=254 cterm=None guibg=None guifg=#e4e4e4 gui=None
-hi TSParameter ctermbg=None ctermfg=254 cterm=None guibg=None guifg=#e4e4e4 gui=None
-hi TSParameterReference ctermbg=None ctermfg=254 cterm=None guibg=None guifg=#e4e4e4 gui=None
-hi TSLabel ctermbg=None ctermfg=254 cterm=None guibg=None guifg=#e4e4e4 gui=None
-hi TSPunctBracket ctermbg=None  ctermfg=108 cterm=None guibg=None  guifg=#87af87 gui=None
-hi TSPunctSpecial ctermbg=None  ctermfg=108 cterm=None guibg=None  guifg=#87af87 gui=None
-hi TSInclude ctermbg=None ctermfg=110 cterm=None guibg=None guifg=#87afd7 gui=None
+hi TSConstant ctermbg=NONE ctermfg=254 cterm=NONE guibg=NONE guifg=#e4e4e4 gui=NONE
+hi TSParameter ctermbg=NONE ctermfg=254 cterm=NONE guibg=NONE guifg=#e4e4e4 gui=NONE
+hi TSParameterReference ctermbg=NONE ctermfg=254 cterm=NONE guibg=NONE guifg=#e4e4e4 gui=NONE
+hi TSLabel ctermbg=NONE ctermfg=254 cterm=NONE guibg=NONE guifg=#e4e4e4 gui=NONE
+hi TSPunctBracket ctermbg=NONE  ctermfg=108 cterm=NONE guibg=NONE  guifg=#87af87 gui=NONE
+hi TSPunctSpecial ctermbg=NONE  ctermfg=108 cterm=NONE guibg=NONE  guifg=#87af87 gui=NONE
+hi TSInclude ctermbg=NONE ctermfg=110 cterm=NONE guibg=NONE guifg=#87afd7 gui=NONE
 
 " NVIM-LSP
-hi LspCodeLens ctermbg=None ctermfg=110 cterm=italic guibg=None guifg=#87afd7 gui=italic
-hi LspCodeLensSeparator ctermbg=None ctermfg=242 cterm=None guibg=None guifg=#6c6c6c gui=None
+hi LspCodeLens ctermbg=NONE ctermfg=110 cterm=italic guibg=NONE guifg=#87afd7 gui=italic
+hi LspCodeLensSeparator ctermbg=NONE ctermfg=242 cterm=NONE guibg=NONE guifg=#6c6c6c gui=NONE
 
 " Neovim Indent-Blankline
 hi IndentBlanklineChar ctermfg=235 guifg=#3a3a3a gui=nocombine
@@ -134,34 +134,34 @@ hi IndentBlanklineContextChar ctermfg=242 guifg=#6c6c6c gui=nocombine
 " gitgutter
 hi GitGutterAdd     ctermfg=022 guifg=#005f00
 hi GitGutterChange  ctermfg=226 guifg=#ffff00
-hi GitGutterDelete  ctermfg=131 guibg=None guifg=#af5f5f cterm=None
+hi GitGutterDelete  ctermfg=131 guibg=NONE guifg=#af5f5f cterm=NONE
 
 " gitsigns
 hi GitSignsAdd     ctermfg=022 guifg=#005f00
 hi GitSignsChange  ctermfg=226 guifg=#ffff00
-hi GitSignsDelete  ctermfg=131 guibg=None guifg=#af5f5f cterm=None
+hi GitSignsDelete  ctermfg=131 guibg=NONE guifg=#af5f5f cterm=NONE
 
 " litee
-hi LTBoolean                guifg=#0087af guibg=None
-hi LTConstant               guifg=#0087af guibg=None
-hi LTConstructor            guifg=#4DC5C6 guibg=None
-hi LTField                  guifg=#0087af guibg=None
-hi LTFunction               guifg=#988ACF guibg=None
-hi LTMethod                 guifg=#0087af guibg=None
-hi LTNamespace              guifg=#87af87 guibg=None
-hi LTNumber                 guifg=#9b885c guibg=None
-hi LTOperator               guifg=#988ACF guibg=None
-hi LTParameter              guifg=#988ACF guibg=None
-hi LTParameterReference     guifg=#4DC5C6 guibg=None
-hi LTString                 guifg=#af5f5f guibg=None
+hi LTBoolean                guifg=#0087af guibg=NONE
+hi LTConstant               guifg=#0087af guibg=NONE
+hi LTConstructor            guifg=#4DC5C6 guibg=NONE
+hi LTField                  guifg=#0087af guibg=NONE
+hi LTFunction               guifg=#988ACF guibg=NONE
+hi LTMethod                 guifg=#0087af guibg=NONE
+hi LTNamespace              guifg=#87af87 guibg=NONE
+hi LTNumber                 guifg=#9b885c guibg=NONE
+hi LTOperator               guifg=#988ACF guibg=NONE
+hi LTParameter              guifg=#988ACF guibg=NONE
+hi LTParameterReference     guifg=#4DC5C6 guibg=NONE
+hi LTString                 guifg=#af5f5f guibg=NONE
 hi LTSymbol                 guifg=#87afd7 gui=underline
 hi LTSymbolDetail           ctermfg=024 cterm=italic guifg=#988ACF gui=italic
 hi LTSymbolJump             ctermfg=015 ctermbg=110 cterm=italic,bold,underline   guifg=#464646 guibg=#87afd7 gui=italic,bold
 hi LTSymbolJumpRefs         ctermfg=015 ctermbg=110 cterm=italic,bold,underline   guifg=#464646 guibg=#9b885c gui=italic,bold
-hi LTType                   guifg=#9b885c guibg=None
-hi LTURI                    guifg=#988ACF guibg=None
-hi LTIndentGuide            guifg=None    guibg=None
-hi LTExpandedGuide          guifg=None    guibg=None
-hi LTCollapsedGuide         guifg=None    guibg=None
-hi LTSelectFiletree         ctermbg=131  ctermfg=246 cterm=None guibg=#af5f5f guifg=#e4e4e4 gui=None
+hi LTType                   guifg=#9b885c guibg=NONE
+hi LTURI                    guifg=#988ACF guibg=NONE
+hi LTIndentGuide            guifg=NONE    guibg=NONE
+hi LTExpandedGuide          guifg=NONE    guibg=NONE
+hi LTCollapsedGuide         guifg=NONE    guibg=NONE
+hi LTSelectFiletree         ctermbg=131  ctermfg=246 cterm=NONE guibg=#af5f5f guifg=#e4e4e4 gui=NONE
 hi def link LTCurrentFileFiletree Visual

--- a/colors/vimlight.vim
+++ b/colors/vimlight.vim
@@ -30,109 +30,109 @@ let g:colors_name = 'vimlight'
 " cyan;             #268889
 
 set background=light
-hi Normal       ctermbg=250  ctermfg=235 cterm=None         guibg=000000  guifg=#464646 gui=None
-hi NormalFloat  ctermbg=250  ctermfg=235 cterm=None         guibg=000000  guifg=#464646 gui=None
-hi NonText      ctermbg=250  ctermfg=235 cterm=None         guibg=000000  guifg=#464646 gui=None
+hi Normal       ctermbg=250  ctermfg=235 cterm=NONE         guibg=#000000  guifg=#464646 gui=NONE
+hi NormalFloat  ctermbg=250  ctermfg=235 cterm=NONE         guibg=#000000  guifg=#464646 gui=NONE
+hi NonText      ctermbg=250  ctermfg=235 cterm=NONE         guibg=#000000  guifg=#464646 gui=NONE
 hi Question     ctermbg=250  ctermfg=235 cterm=Bold         guibg=#bcbcbc  guifg=#464646 gui=Bold
 hi MoreMsg      ctermbg=250  ctermfg=235 cterm=Bold         guibg=#bcbcbc  guifg=#464646 gui=Bold
-hi Visual       ctermbg=110  ctermfg=000 cterm=None         guibg=#87afd7  guifg=#000000 gui=None
-hi Comment      ctermbg=None ctermfg=242 cterm=None         guibg=None guifg=#6c6c6c gui=None
-hi Constant     ctermbg=None ctermfg=024 cterm=None         guibg=None guifg=#005f87 gui=None 
-hi String       ctermbg=None ctermfg=131 cterm=None         guibg=None guifg=#af5f5f gui=None 
-hi Character    ctermbg=None ctermfg=024 cterm=None         guibg=None guifg=#005f87 gui=None
-hi Identifier   ctermbg=None ctermfg=None cterm=None        guibg=None guifg=None gui=None
-hi Statement    ctermbg=None ctermfg=024 cterm=None         guibg=None guifg=#005f87 gui=None
-hi PreProc      ctermbg=None ctermfg=024 cterm=None         guibg=None guifg=#005f87 gui=None
-hi Operator     ctermbg=None ctermfg=131 cterm=None         guibg=None guifg=#af5f5f gui=None
-hi Type         ctermbg=None ctermfg=024 cterm=None         guibg=None guifg=#005f87 gui=None
-hi Special      ctermbg=None ctermfg=024 cterm=None         guibg=None guifg=#005f87 gui=None 
-hi Underlined   ctermbg=None ctermfg=None cterm=Underline   guibg=None guifg=None gui=Underline
-hi Ignore       ctermbg=None ctermfg=None cterm=None        guibg=None guifg=None gui=None
-hi Error        ctermbg=None ctermfg=196 cterm=None         guibg=None guifg=#ff0000 gui=None
-hi ErrorMsg     ctermbg=131  ctermfg=246 cterm=None         guibg=#af5f5f guifg=#e4e4e4 gui=None
-hi Warning      ctermbg=None ctermfg=024 cterm=None         guibg=None guifg=#005f87 gui=None
-hi WarningMsg   ctermbg=None ctermfg=024 cterm=None         guibg=None guifg=#005f87 gui=None
-hi Todo         ctermbg=None ctermfg=024 cterm=None         guibg=None guifg=#005f87 gui=None
-hi Cursor       ctermbg=235  ctermfg=250  cterm=None        guibg=#464646  guifg=#bcbcbc  gui=None
-hi CursorLine   ctermbg=254  ctermfg=None cterm=Bold        guibg=#e4e4e4  guifg=None gui=Bold
-hi Directory    ctermbg=None  ctermfg=235 cterm=Underline   guibg=None  guifg=#464646 gui=Underline
-hi VertSplit    ctermbg=None  ctermfg=235 cterm=Bold        guibg=None  guifg=#464646 gui=Bold
-hi Folded       ctermbg=None ctermfg=None cterm=None        guibg=None guifg=None gui=None
-hi FoldColumn   ctermbg=None ctermfg=242 cterm=None         guibg=None guifg=#6c6c6c gui=None
-hi SignColumn   ctermbg=None ctermfg=None cterm=None        guibg=None guifg=None gui=None
+hi Visual       ctermbg=110  ctermfg=000 cterm=NONE         guibg=#87afd7  guifg=#000000 gui=NONE
+hi Comment      ctermbg=NONE ctermfg=242 cterm=NONE         guibg=NONE guifg=#6c6c6c gui=NONE
+hi Constant     ctermbg=NONE ctermfg=024 cterm=NONE         guibg=NONE guifg=#005f87 gui=NONE 
+hi String       ctermbg=NONE ctermfg=131 cterm=NONE         guibg=NONE guifg=#af5f5f gui=NONE 
+hi Character    ctermbg=NONE ctermfg=024 cterm=NONE         guibg=NONE guifg=#005f87 gui=NONE
+hi Identifier   ctermbg=NONE ctermfg=NONE cterm=NONE        guibg=NONE guifg=NONE gui=NONE
+hi Statement    ctermbg=NONE ctermfg=024 cterm=NONE         guibg=NONE guifg=#005f87 gui=NONE
+hi PreProc      ctermbg=NONE ctermfg=024 cterm=NONE         guibg=NONE guifg=#005f87 gui=NONE
+hi Operator     ctermbg=NONE ctermfg=131 cterm=NONE         guibg=NONE guifg=#af5f5f gui=NONE
+hi Type         ctermbg=NONE ctermfg=024 cterm=NONE         guibg=NONE guifg=#005f87 gui=NONE
+hi Special      ctermbg=NONE ctermfg=024 cterm=NONE         guibg=NONE guifg=#005f87 gui=NONE 
+hi Underlined   ctermbg=NONE ctermfg=NONE cterm=Underline   guibg=NONE guifg=NONE gui=Underline
+hi Ignore       ctermbg=NONE ctermfg=NONE cterm=NONE        guibg=NONE guifg=NONE gui=NONE
+hi Error        ctermbg=NONE ctermfg=196 cterm=NONE         guibg=NONE guifg=#ff0000 gui=NONE
+hi ErrorMsg     ctermbg=131  ctermfg=246 cterm=NONE         guibg=#af5f5f guifg=#e4e4e4 gui=NONE
+hi Warning      ctermbg=NONE ctermfg=024 cterm=NONE         guibg=NONE guifg=#005f87 gui=NONE
+hi WarningMsg   ctermbg=NONE ctermfg=024 cterm=NONE         guibg=NONE guifg=#005f87 gui=NONE
+hi Todo         ctermbg=NONE ctermfg=024 cterm=NONE         guibg=NONE guifg=#005f87 gui=NONE
+hi Cursor       ctermbg=235  ctermfg=250  cterm=NONE        guibg=#464646  guifg=#bcbcbc  gui=NONE
+hi CursorLine   ctermbg=254  ctermfg=NONE cterm=Bold        guibg=#e4e4e4  guifg=NONE gui=Bold
+hi Directory    ctermbg=NONE  ctermfg=235 cterm=Underline   guibg=NONE  guifg=#464646 gui=Underline
+hi VertSplit    ctermbg=NONE  ctermfg=235 cterm=Bold        guibg=NONE  guifg=#464646 gui=Bold
+hi Folded       ctermbg=NONE ctermfg=NONE cterm=NONE        guibg=NONE guifg=NONE gui=NONE
+hi FoldColumn   ctermbg=NONE ctermfg=242 cterm=NONE         guibg=NONE guifg=#6c6c6c gui=NONE
+hi SignColumn   ctermbg=NONE ctermfg=NONE cterm=NONE        guibg=NONE guifg=NONE gui=NONE
 hi IncSearch    ctermbg=227  ctermfg=000 cterm=BOLD         guibg=#806CCF  guifg=#ffffff gui=Bold
 hi Search       ctermbg=227  ctermfg=000 cterm=BOLD         guibg=#806CCF  guifg=#ffffff gui=Bold
-hi LineNr       ctermbg=None ctermfg=237 cterm=None         guibg=None guifg=#3a3a3a gui=None
-hi CursorLineNr ctermbg=None ctermfg=244 cterm=Bold         guibg=None guifg=#808080 gui=Bold
-hi MatchParen   ctermbg=110  ctermfg=000 cterm=None         guibg=#87afd7  guifg=#000000 gui=None
-hi Pmenu        ctermbg=254  ctermfg=235 cterm=None         guibg=#e4e4e4  guifg=#464646 gui=None
+hi LineNr       ctermbg=NONE ctermfg=237 cterm=NONE         guibg=NONE guifg=#3a3a3a gui=NONE
+hi CursorLineNr ctermbg=NONE ctermfg=244 cterm=Bold         guibg=NONE guifg=#808080 gui=Bold
+hi MatchParen   ctermbg=110  ctermfg=000 cterm=NONE         guibg=#87afd7  guifg=#000000 gui=NONE
+hi Pmenu        ctermbg=254  ctermfg=235 cterm=NONE         guibg=#e4e4e4  guifg=#464646 gui=NONE
 hi PmenuSel     ctermbg=110  ctermfg=235 cterm=Bold         guibg=#87afd7  guifg=#464646 gui=Bold
-hi PmenuSbar    ctermbg=254  ctermfg=235 cterm=None         guibg=#e4e4e4  guifg=#464646 gui=None
-hi PmenuThumb   ctermbg=110  ctermfg=235 cterm=None         guibg=#87afd7  guifg=#464646 gui=None
-hi SpecialKey   ctermbg=None ctermfg=039 cterm=None         guibg=None guifg=#00afff gui=None
+hi PmenuSbar    ctermbg=254  ctermfg=235 cterm=NONE         guibg=#e4e4e4  guifg=#464646 gui=NONE
+hi PmenuThumb   ctermbg=110  ctermfg=235 cterm=NONE         guibg=#87afd7  guifg=#464646 gui=NONE
+hi SpecialKey   ctermbg=NONE ctermfg=039 cterm=NONE         guibg=NONE guifg=#00afff gui=NONE
 hi StatusLine   ctermbg=254  ctermfg=235 cterm=Bold         guibg=#e4e4e4  guifg=#464646 gui=Bold
-hi StatusLineNC ctermbg=254  ctermfg=235 cterm=None         guibg=#e4e4e4  guifg=#464646 gui=None
+hi StatusLineNC ctermbg=254  ctermfg=235 cterm=NONE         guibg=#e4e4e4  guifg=#464646 gui=NONE
 hi WildMenu     ctermbg=110  ctermfg=235 cterm=Bold         guibg=#87afd7  guifg=#464646 gui=Bold
-hi TabLine      ctermbg=254  ctermfg=235 cterm=None         guibg=#e4e4e4  guifg=#464646 gui=None
-hi TabLineFill  ctermbg=254  ctermfg=235 cterm=None         guibg=#e4e4e4  guifg=#464646 gui=None
+hi TabLine      ctermbg=254  ctermfg=235 cterm=NONE         guibg=#e4e4e4  guifg=#464646 gui=NONE
+hi TabLineFill  ctermbg=254  ctermfg=235 cterm=NONE         guibg=#e4e4e4  guifg=#464646 gui=NONE
 hi TabLineSel   ctermbg=229  ctermfg=235 cterm=Bold         guibg=#ffffaf  guifg=#464646 gui=Bold
-hi Title        ctermbg=None ctermfg=None cterm=Bold        guibg=None guifg=None gui=Bold
-hi Keyword      ctermbg=None ctermfg=024 cterm=None         guibg=None guifg=#005f87 gui=None
-hi DiffAdd      ctermbg=108  ctermfg=000 cterm=None         guibg=#87af87  guifg=#000000 gui=None
-hi DiffDelete   ctermbg=131  ctermfg=000 cterm=None         guibg=#af5f5f  guifg=#000000 gui=None
-hi DiffChange   ctermbg=110  ctermfg=000 cterm=None         guibg=#87afd7  guifg=#000000 gui=None
-hi DiffText     ctermbg=108  ctermfg=000 cterm=None         guibg=#87af87  guifg=#000000 gui=None
-hi qfLineNr     ctermbg=None ctermfg=None cterm=Bold        guibg=None guifg=None gui=Bold
+hi Title        ctermbg=NONE ctermfg=NONE cterm=Bold        guibg=NONE guifg=NONE gui=Bold
+hi Keyword      ctermbg=NONE ctermfg=024 cterm=NONE         guibg=NONE guifg=#005f87 gui=NONE
+hi DiffAdd      ctermbg=108  ctermfg=000 cterm=NONE         guibg=#87af87  guifg=#000000 gui=NONE
+hi DiffDelete   ctermbg=131  ctermfg=000 cterm=NONE         guibg=#af5f5f  guifg=#000000 gui=NONE
+hi DiffChange   ctermbg=110  ctermfg=000 cterm=NONE         guibg=#87afd7  guifg=#000000 gui=NONE
+hi DiffText     ctermbg=108  ctermfg=000 cterm=NONE         guibg=#87af87  guifg=#000000 gui=NONE
+hi qfLineNr     ctermbg=NONE ctermfg=NONE cterm=Bold        guibg=NONE guifg=NONE gui=Bold
 
 "golang
-hi goField              ctermbg=None ctermfg=None cterm=None
-hi goType               ctermbg=None ctermfg=024  cterm=None guibg=None guifg=#005f87 gui=None
-hi goSignedInts         ctermbg=None ctermfg=024  cterm=None guibg=None guifg=#005f87 gui=None
-hi goUnsignedInts       ctermbg=None ctermfg=024  cterm=None guibg=None guifg=#005f87 gui=None
-hi goFloats             ctermbg=None ctermfg=024  cterm=None guibg=None guifg=#005f87 gui=None
-hi goTypeName           ctermbg=None ctermfg=235  cterm=None guibg=None guifg=#464646 gui=None
-hi goDiagnosticError    ctermbg=None ctermfg=None cterm=None
-hi goDiagnosticWarning  ctermbg=None ctermfg=None cterm=None
+hi goField              ctermbg=NONE ctermfg=NONE cterm=NONE
+hi goType               ctermbg=NONE ctermfg=024  cterm=NONE guibg=NONE guifg=#005f87 gui=NONE
+hi goSignedInts         ctermbg=NONE ctermfg=024  cterm=NONE guibg=NONE guifg=#005f87 gui=NONE
+hi goUnsignedInts       ctermbg=NONE ctermfg=024  cterm=NONE guibg=NONE guifg=#005f87 gui=NONE
+hi goFloats             ctermbg=NONE ctermfg=024  cterm=NONE guibg=NONE guifg=#005f87 gui=NONE
+hi goTypeName           ctermbg=NONE ctermfg=235  cterm=NONE guibg=NONE guifg=#464646 gui=NONE
+hi goDiagnosticError    ctermbg=NONE ctermfg=NONE cterm=NONE
+hi goDiagnosticWarning  ctermbg=NONE ctermfg=NONE cterm=NONE
 
 "javascript
-hi jsObjectKey ctermbg=None ctermfg=131 cterm=None 
+hi jsObjectKey ctermbg=NONE ctermfg=131 cterm=NONE 
 
 " python
-hi pythonClassVar    ctermbg=None ctermfg=131 cterm=None guibg=None guifg=#af5f5f cterm=None
-hi pythonDottedName  ctermbg=None ctermfg=131 cterm=None guibg=None guifg=#af5f5f cterm=None
-hi pythonDottedName  ctermbg=None ctermfg=131 cterm=None guibg=None guifg=#af5f5f cterm=None
-hi pythonBuiltinFunc ctermbg=None ctermfg=131 cterm=None guibg=None guifg=#af5f5f cterm=None
+hi pythonClassVar    ctermbg=NONE ctermfg=131 cterm=NONE guibg=NONE guifg=#af5f5f cterm=NONE
+hi pythonDottedName  ctermbg=NONE ctermfg=131 cterm=NONE guibg=NONE guifg=#af5f5f cterm=NONE
+hi pythonDottedName  ctermbg=NONE ctermfg=131 cterm=NONE guibg=NONE guifg=#af5f5f cterm=NONE
+hi pythonBuiltinFunc ctermbg=NONE ctermfg=131 cterm=NONE guibg=NONE guifg=#af5f5f cterm=NONE
 
 "c++/c
-hi cppSTLios      ctermbg=None ctermfg=131 guibg=None guifg=#af5f5f cterm=None
-hi cCustomFunc    ctermbg=None ctermfg=131 guibg=None guifg=#af5f5f cterm=None
-hi cStructure     ctermbg=None ctermfg=131 guibg=None guifg=#af5f5f cterm=None
+hi cppSTLios      ctermbg=NONE ctermfg=131 guibg=NONE guifg=#af5f5f cterm=NONE
+hi cCustomFunc    ctermbg=NONE ctermfg=131 guibg=NONE guifg=#af5f5f cterm=NONE
+hi cStructure     ctermbg=NONE ctermfg=131 guibg=NONE guifg=#af5f5f cterm=NONE
 
 " gitgutter
 highlight GitGutterAdd     ctermfg=022 guifg=#005f00
 highlight GitGutterChange  ctermfg=226 guifg=#ffff00
-highlight GitGutterDelete  ctermfg=131 guibg=None guifg=#af5f5f cterm=None
+highlight GitGutterDelete  ctermfg=131 guibg=NONE guifg=#af5f5f cterm=NONE
 
 " gitsigns
 hi GitSignsAdd     ctermfg=022 guifg=#005f00
 hi GitSignsChange  ctermfg=226 guifg=#ffff00
-hi GitSignsDelete  ctermfg=131 guibg=None guifg=#af5f5f cterm=None
+hi GitSignsDelete  ctermfg=131 guibg=NONE guifg=#af5f5f cterm=NONE
 
-hi helpExample ctermbg=None ctermfg=024 cterm=None guibg=None guifg=#005f87 gui=None
-hi helpCommand ctermbg=None ctermfg=024 cterm=None guibg=None guifg=#005f87 gui=None
+hi helpExample ctermbg=NONE ctermfg=024 cterm=NONE guibg=NONE guifg=#005f87 gui=NONE
+hi helpCommand ctermbg=NONE ctermfg=024 cterm=NONE guibg=NONE guifg=#005f87 gui=NONE
 
 " TreeSitter
-hi TSConstant ctermbg=None ctermfg=254 cterm=None guibg=None guifg=#af5f5f gui=None
-hi TSParameter ctermbg=None ctermfg=254 cterm=None guibg=None guifg=#806CCF gui=None
-hi TSParameterReference ctermbg=None ctermfg=254 cterm=None guibg=None guifg=#000000 gui=None
-hi TSLabel ctermbg=None ctermfg=254 cterm=None guibg=None guifg=#000000 gui=None
-hi TSPunctBracket ctermbg=None  ctermfg=108 cterm=None guibg=None  guifg=#005f00 gui=None
-hi TSPunctSpecial ctermbg=None  ctermfg=108 cterm=None guibg=None  guifg=#005f00 gui=None
-hi TSInclude ctermbg=None ctermfg=110 cterm=None guibg=None guifg=#005f87 gui=None
+hi TSConstant ctermbg=NONE ctermfg=254 cterm=NONE guibg=NONE guifg=#af5f5f gui=NONE
+hi TSParameter ctermbg=NONE ctermfg=254 cterm=NONE guibg=NONE guifg=#806CCF gui=NONE
+hi TSParameterReference ctermbg=NONE ctermfg=254 cterm=NONE guibg=NONE guifg=#000000 gui=NONE
+hi TSLabel ctermbg=NONE ctermfg=254 cterm=NONE guibg=NONE guifg=#000000 gui=NONE
+hi TSPunctBracket ctermbg=NONE  ctermfg=108 cterm=NONE guibg=NONE  guifg=#005f00 gui=NONE
+hi TSPunctSpecial ctermbg=NONE  ctermfg=108 cterm=NONE guibg=NONE  guifg=#005f00 gui=NONE
+hi TSInclude ctermbg=NONE ctermfg=110 cterm=NONE guibg=NONE guifg=#005f87 gui=NONE
 
 " NVIM-LSP
-hi LspCodeLens ctermbg=None ctermfg=024 cterm=italic guibg=None guifg=#005f87 gui=italic
-hi LspCodeLensSeparator ctermbg=None ctermfg=242 cterm=italic guibg=None guifg=#6c6c6c
+hi LspCodeLens ctermbg=NONE ctermfg=024 cterm=italic guibg=NONE guifg=#005f87 gui=italic
+hi LspCodeLensSeparator ctermbg=NONE ctermfg=242 cterm=italic guibg=NONE guifg=#6c6c6c
 
 " Neovim Indent-Blankline
 hi IndentBlanklineChar ctermfg=248 guifg=#9e9e9e gui=nocombine
@@ -141,26 +141,26 @@ hi IndentBlanklineSpaceCharBlankline ctermfg=242 guifg=#6c6c6c gui=nocombine
 hi IndentBlanklineContextChar ctermfg=242 guifg=#6c6c6c gui=nocombine
 
 " litee
-hi LTBoolean                guifg=#005f87 guibg=None
-hi LTConstant               guifg=#005f87 guibg=None
-hi LTConstructor            guifg=#9b885c guibg=None
-hi LTField                  guifg=#005f87 guibg=None
-hi LTFunction               guifg=#806CCF guibg=None
-hi LTMethod                 guifg=#005f87 guibg=None
-hi LTNamespace              guifg=#87af87 guibg=None
-hi LTNumber                 guifg=#9b885c guibg=None
-hi LTOperator               guifg=#806CCF guibg=None
-hi LTParameter              guifg=#806CCF guibg=None
-hi LTParameterReference     guifg=#268889 guibg=None
-hi LTString                 guifg=#af5f5f guibg=None
+hi LTBoolean                guifg=#005f87 guibg=NONE
+hi LTConstant               guifg=#005f87 guibg=NONE
+hi LTConstructor            guifg=#9b885c guibg=NONE
+hi LTField                  guifg=#005f87 guibg=NONE
+hi LTFunction               guifg=#806CCF guibg=NONE
+hi LTMethod                 guifg=#005f87 guibg=NONE
+hi LTNamespace              guifg=#87af87 guibg=NONE
+hi LTNumber                 guifg=#9b885c guibg=NONE
+hi LTOperator               guifg=#806CCF guibg=NONE
+hi LTParameter              guifg=#806CCF guibg=NONE
+hi LTParameterReference     guifg=#268889 guibg=NONE
+hi LTString                 guifg=#af5f5f guibg=NONE
 hi LTSymbol                 guifg=#806CCF gui=underline
 hi LTSymbolDetail           ctermfg=024 cterm=italic guifg=#005f87 gui=italic
 hi LTSymbolJump             ctermfg=015 ctermbg=110 cterm=italic,bold,underline   guifg=#464646 guibg=#87afd7 gui=italic,bold
 hi LTSymbolJumpRefs         ctermfg=015 ctermbg=110 cterm=italic,bold,underline   guifg=#464646 guibg=#9b885c gui=italic,bold
-hi LTType                   guifg=#268889 guibg=None
-hi LTURI                    guifg=#806CCF guibg=None
-hi LTIndentGuide            guifg=None    guibg=None
-hi LTExpandedGuide          guifg=None    guibg=None
-hi LTCollapsedGuide         guifg=None    guibg=None
-hi LTSelectFiletree ctermbg=131  ctermfg=246 cterm=None guibg=#af5f5f guifg=#e4e4e4 gui=None
+hi LTType                   guifg=#268889 guibg=NONE
+hi LTURI                    guifg=#806CCF guibg=NONE
+hi LTIndentGuide            guifg=NONE    guibg=NONE
+hi LTExpandedGuide          guifg=NONE    guibg=NONE
+hi LTCollapsedGuide         guifg=NONE    guibg=NONE
+hi LTSelectFiletree ctermbg=131  ctermfg=246 cterm=NONE guibg=#af5f5f guifg=#e4e4e4 gui=NONE
 hi def link LTCurrentFileFiletree Visual


### PR DESCRIPTION
- Replace color 000000 to #000000
- Replace color None to NONE
- vimdark fix typo #e4e44 

tested in vim/gvim.